### PR TITLE
Update costFunctionReg.m [Formula for J]

### DIFF
--- a/mlclass-ex2/costFunctionReg.m
+++ b/mlclass-ex2/costFunctionReg.m
@@ -22,7 +22,7 @@ z=X*theta;
 h=sigmoid(z);
 logisf=(-y)'*log(h)-(1-y)'*log(1-h);
 
-J=((1/m).*sum(logisf))+(lambda/(2*m)).*sum(theta.^2);
+J=((1/m).*sum(logisf))+(lambda/(2*m)).*sum(theta(2:length(theta)).^2);
 
 k=length(theta)-1;
 n=length(theta);


### PR DESCRIPTION
[On line number: 25]
The current formula to find the cost (J) fails, as it also includes the theta(1) parameter in the calculations. We should not be regularizing the theta(1) parameter in the code as theta(1) parameter is not affected by the lambda parameter in logistic regression. Hence, that theta(1) parameter must be removed. So, I used "theta(2:length(theta))" instead of "theta" in the formula to find J, so as to exclude theta(1) parameter and find the correct value for J.